### PR TITLE
fix: bump appvia/network/aws example to v0.6.14 for AWS provider 6.x …

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -69,11 +69,11 @@ locals {
 ## Provision the VPC for VPN
 module "vpc" {
   source  = "appvia/network/aws"
-  version = "0.3.0"
+  version = "0.6.14"
 
   availability_zones     = var.availability_zones
-  enable_ipam            = var.ipam_pool_id != "" ? true : false
-  enable_transit_gateway = var.transit_gateway_id != "" ? true : false
+  # enable_ipam            = var.ipam_pool_id != "" ? true : false
+  # enable_transit_gateway = var.transit_gateway_id != "" ? true : false
   ipam_pool_id           = var.ipam_pool_id
   name                   = var.name
   private_subnet_netmask = var.private_subnet_netmask

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -71,7 +71,7 @@ module "vpc" {
   source  = "appvia/network/aws"
   version = "0.6.14"
 
-  availability_zones     = var.availability_zones
+  availability_zones = var.availability_zones
   # enable_ipam            = var.ipam_pool_id != "" ? true : false
   # enable_transit_gateway = var.transit_gateway_id != "" ? true : false
   ipam_pool_id           = var.ipam_pool_id

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
**Description:**

The Terraform Validate Examples CI job was failing because appvia/network/aws 0.3.0 constrains the AWS provider to ~> 5.0 (< 6.0), conflicting with the root module's ~> 6.22 constraint introduced in #72.

**Changes:**

- Bump appvia/network/aws in the basic example from 0.3.0 → 0.6.14, which supports AWS provider ~> 6.0
- Remove enable_ipam and enable_transit_gateway - both were dropped from the module interface and are now auto-inferred from ipam_pool_id and transit_gateway_id, respectively
- Update the example's AWS provider constraint from >= 5.0.0 → ~> 6.0 to be consistent with the root module